### PR TITLE
Repo name change, avoid name/package confusion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,15 @@
 name = "grinbot"
 version = "0.0.1"
 authors = ["Alex Byrnes"]
+
+license = "MIT"
+description = "Telegram bot for Grin"
+homepage = "https://github.com/alexbyrnes/grinbot"
+documentation = "https://github.com/alexbyrnes/grinbot"
+repository = "https://github.com/alexbyrnes/grinbot"
+keywords = [ "cryptocurrency", "blockchain", "wallet", "chatbot", "mimblewimble", "grin" ]
+categories = [ "cryptography::cryptocurrencies" ]
+readme = "README.md"
 edition = "2018"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# GrinBot
+# Grin Bot
 
-GrinBot is a self-hosted Telegram bot wallet for the [Grin](https://grin-tech.org/) cryptocurrency. You can run GrinBot on your own hardware, and interact with it through Telegram messages.
+Grin Bot is a self-hosted Telegram bot wallet for the [Grin](https://grin-tech.org/) cryptocurrency. You can run Grin Bot on your own hardware, and interact with it through Telegram messages.
 
 ![Mobile](screenshots/mobile.png)
 
@@ -11,8 +11,8 @@ GrinBot is a self-hosted Telegram bot wallet for the [Grin](https://grin-tech.or
 ### Docker
 
 ```shell
-git clone --branch v0.0.1 https://github.com/alexbyrnes/GrinBot.git
-cd GrinBot
+git clone --branch v0.0.1 https://github.com/alexbyrnes/grinbot.git
+cd grinbot
 docker build -t grinbot .
 docker run -it grinbot
 ```
@@ -20,14 +20,14 @@ docker run -it grinbot
 ### From source
 
 ```shell
-git clone --branch v0.0.1 https://github.com/alexbyrnes/GrinBot.git
-cargo install --path GrinBot --locked
+git clone --branch v0.0.1 https://github.com/alexbyrnes/grinbot.git
+cargo install --path grinbot --locked
 ```
 
 ### From source &mdash; no install
 ```shell
-git clone --branch v0.0.1 https://github.com/alexbyrnes/GrinBot.git
-cd GrinBot
+git clone --branch v0.0.1 https://github.com/alexbyrnes/grinbot.git
+cd grinbot
 cargo run
 ```
 
@@ -67,11 +67,11 @@ Note: The best source of troubleshooting information is the [dockerfile](dockerf
 
 ## Architecture and Security
 
-GrinBot uses the Telegram bot long polling interface. This means there's no need for an externally-accessible IP or port. GrinBot will connect to Telegram and pull new messages (called [Updates](https://core.telegram.org/bots/api#getting-updates)) from an endpoint specifically for your bot instance using your token. To get an idea of how this works, you can visit `https://api.telegram.org/bot<your api token>/getUpdates` to manually consume messages you have sent your bot. This is the address GrinBot polls.
+Grin Bot uses the Telegram bot long polling interface. This means there's no need for an externally-accessible IP or port. Grin Bot will connect to Telegram and pull new messages (called [Updates](https://core.telegram.org/bots/api#getting-updates)) from an endpoint specifically for your bot instance using your token. To get an idea of how this works, you can visit `https://api.telegram.org/bot<your api token>/getUpdates` to manually consume messages you have sent your bot. This is the address Grin Bot polls.
 
 The only information that is sent to Telegram is the contents of the chat itself &mdash; the commands you send to your bot and the messages it sends back. The commands and replies do not include passwords or tokens.
 
-Telegram bot traffic is _not_ end-to-end encrypted, however Telegram claims [GDPR compliance](https://telegram.org/faq#q-what-about-gdpr) and the ability to [delete messages](https://telegram.org/faq#q-can-i-delete-my-messages). If you are using GrinBot for purposes that require stronger security guarantees than these, you should not use this version.
+Telegram bot traffic is _not_ end-to-end encrypted, however Telegram claims [GDPR compliance](https://telegram.org/faq#q-what-about-gdpr) and the ability to [delete messages](https://telegram.org/faq#q-can-i-delete-my-messages). If you are using Grin Bot for purposes that require stronger security guarantees than these, you should not use this version.
 
 
 ## Roadmap

--- a/dockerfile
+++ b/dockerfile
@@ -19,12 +19,12 @@ RUN git clone --branch v2.0.0 https://github.com/mimblewimble/grin-wallet.git
 RUN cargo install --path grin-wallet
 
 # make bot, wallet, and node directories
-RUN mkdir GrinBot
+RUN mkdir grinbot
 RUN mkdir mywallet
 RUN mkdir node
 
 # copy repo into container
-COPY . GrinBot
+COPY . grinbot
 
 # initialize grin wallet
 WORKDIR /mywallet
@@ -36,7 +36,7 @@ RUN grin server config && \
     sed -i -e 's/run_tui = true/run_tui = false/' grin-server.toml
 
 # initialize bot
-WORKDIR /GrinBot
+WORKDIR /grinbot
 RUN chmod u+x scripts/docker_entrypoint.sh
 RUN cargo build
 

--- a/scripts/docker_entrypoint.sh
+++ b/scripts/docker_entrypoint.sh
@@ -4,5 +4,5 @@ cd /node
 grin server run &
 cd /mywallet
 grin-wallet -p pass owner_api &
-cd /GrinBot
+cd /grinbot
 cargo run

--- a/src/controller/dispatch.rs
+++ b/src/controller/dispatch.rs
@@ -83,14 +83,14 @@ pub fn screen_reducer(state: &State, action: &Action) -> State {
         }
         Action::NoUsername(id) => State {
             id: Some(*id),
-            message: Some("You must have a username to use GrinBot.".into()),
+            message: Some("You must have a username to use Grin Bot.".into()),
             error_level: Some(Level::Warn),
             ..s
         },
         Action::WrongUsername(id) => State {
             id: Some(*id),
             message: Some(
-                "Your username does not match the username in the GrinBot config.".into(),
+                "Your username does not match the username in the Grin Bot config.".into(),
             ),
             error_level: Some(Level::Warn),
             ..s

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ fn load_config_field(config: &Yaml, field: &str) -> String {
 
 fn main() {
     // Parse optional chat message from command line
-    let matches = App::new("GrinBot")
+    let matches = App::new("Grin Bot")
         .arg(
             Arg::with_name("command")
                 .short("c")
@@ -156,7 +156,7 @@ fn main() {
 
     // Logging
     log4rs::init_file(log_config, Default::default()).unwrap();
-    info!("Starting GrinBot...");
+    info!("Starting Grin Bot...");
     let logging_listener: Subscription<State> = |state: &State| {
         // Log actions with a log level
         if let Some(level) = state.error_level {

--- a/templates/help.html
+++ b/templates/help.html
@@ -1,4 +1,4 @@
-Commands start with a forward slash (/). Some of the commands are available on the dedicated keyboard, and some require more information from you. To issue a command to GrinBot, type one of the following:
+Commands start with a forward slash (/). Some of the commands are available on the dedicated keyboard, and some require more information from you. To issue a command to Grin Bot, type one of the following:
   <pre>/create</pre>
   <i>Create a Grin wallet in the directory specified in your config.yml.</i>
   <pre>/send 0.001 http://some-recipient123.org</pre>
@@ -11,7 +11,7 @@ Commands start with a forward slash (/). Some of the commands are available on t
 
 <b>Technical Information</b>
 
-GrinBot requires a running Grin Wallet Owner API. You can specify the location of your owner API in config.yml.
+Grin Bot requires a running Grin Wallet Owner API. You can specify the location of your owner API in config.yml.
 
 You may specify an existing wallet directory in config.yml.
 
@@ -21,6 +21,6 @@ Errors, and most user actions are logged on your machine. See logging.yml.
 
 Telegram bot traffic is <i>not</i> end-to-end encrypted. However, your wallet password, API key, and seed file are stored on your machine and not transmitted.
 
-The chat text including the recipient's address or IP and amount <i>are</i> transmitted to Telegram's servers. If this is sensitive information you do not want in a Telegram chat, you should not use this version of GrinBot.
+The chat text including the recipient's address or IP and amount <i>are</i> transmitted to Telegram's servers. If this is sensitive information you do not want in a Telegram chat, you should not use this version of Grin Bot.
 
-GrinBot does not respond to "inline" messages used in group chats.
+Grin Bot does not respond to "inline" messages used in group chats.


### PR DESCRIPTION
Changes:

* Change docs to reflect repo name changes
* GrinBot --> Grin Bot to avoid confusion with crate name
* Prepare Cargo.toml for crate